### PR TITLE
Simplify logical expressions

### DIFF
--- a/include/assert.hpp
+++ b/include/assert.hpp
@@ -184,9 +184,9 @@ namespace assert_detail {
 		if constexpr(std::is_signed_v<T> == std::is_signed_v<U>)
 			return t == u;
 		else if constexpr(std::is_signed_v<T>)
-			return t < 0 ? false : UT(t) == u;
+			return t >= 0 && UT(t) == u;
 		else
-			return u < 0 ? false : t == UU(u);
+			return u >= 0 && t == UU(u);
 	}
 
 	template<typename T, typename U>
@@ -203,9 +203,9 @@ namespace assert_detail {
 		if constexpr(std::is_signed_v<T> == std::is_signed_v<U>)
 			return t < u;
 		else if constexpr(std::is_signed_v<T>)
-			return t < 0 ? true : UT(t) < u;
+			return t < 0  || UT(t) < u;
 		else
-			return u < 0 ? false : t < UU(u);
+			return u >= 0 && t < UU(u);
 	}
 
 	template<typename T, typename U>
@@ -217,7 +217,7 @@ namespace assert_detail {
 	template<typename T, typename U>
 	[[gnu::cold]] [[nodiscard]]
 	constexpr bool cmp_less_equal(T t, U u) {
-		return !cmp_greater(t, u);
+		return !cmp_less(u, t);
 	}
 
 	template<typename T, typename U>


### PR DESCRIPTION
This change simplifies some logical expressions using the conditional operator to just `||` and `&&` . For example:
```cpp
return t < 0 ? false : UT(t) == u;
// can be simplified to
return t >= 0 && UT(t) == u;
```
Also, for consistency and to avoid an unnecessary instantiation of `cmp_greater`, `cmp_less_equal` is implemented directly in terms of `cmp_less` like the other two secondary comparisons.