### PR TITLE
Improve codegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ FILE* f = VERIFY(fopen(path, "r") != nullptr, "Internal error with foobars", err
 
 Special handling is provided for `errno`, and strerror is automatically called.
 
+Note: Extra diagnostics are only evaluated in the failure path of an assertion.
+
 ![](screenshots/f.png)
 
 #### Stack Traces <!-- omit in toc -->
@@ -203,9 +205,6 @@ void CHECK(<expression>, [optional assertion message],
                          [optional extra diagnostics, ...], fatal?);
 ```
 
-The macros are all caps to conform with macro hygiene practice - "check" and "verify" they're likely
-to conflict with other identifiers.
-
 `-DASSERT_LOWERCASE` can be used to enable the `assert` alias for `ASSERT`. See:
 [Replacing &lt;cassert&gt;](#replacing-cassert).
 
@@ -236,6 +235,8 @@ string, to be an extra diagnostic value instead simply pass an empty string firs
 
 An arbitrary number of extra diagnostic values may be provided. These are displayed below the
 expression diagnostics if a check fails.
+
+Note: Extra diagnostics are only evaluated in the failure path of an assertion.
 
 There is special handling when `errno` is provided: The value of `strerror` is displayed
 automatically.
@@ -371,8 +372,11 @@ namespace asserts {
 	namespace detail { /* internals */ }
 }
 using asserts::ASSERTION;
-// All macros of the form ASSERT_DETAIL_* are reserved
 ```
+
+This library defines macros of the form `ASSERT_DETAIL_*`. In macro expansion variables of the form
+`assert_detail_*` are created. The user shouldn't define variables of this form to prevent shadowing
+issues.
 
 ## How To Use This Library
 

--- a/include/assert.hpp
+++ b/include/assert.hpp
@@ -905,12 +905,12 @@ using asserts::ASSERTION;
  // with decltype(auto) in an expression like decltype(auto) x = __extension__ ({...}).y;
  #define ASSERT_DETAIL_STMTEXPR(B, R) (__extension__ ({ B R }))
  #define ASSERT_DETAIL_WARNING_PRAGMA _Pragma("GCC diagnostic ignored \"-Wparentheses\"")
- #define ASSERT_DETAIL_PFUNC_INVOKER_V ASSERT_DETAIL_PFUNC
+ #define ASSERT_DETAIL_PFUNC_INVOKER_VALUE ASSERT_DETAIL_PFUNC
  #define ASSERT_DETAIL_STATIC_CAST_TO_BOOL(x) static_cast<bool>(x)
 #else
- #define ASSERT_DETAIL_STMTEXPR(B, R) [&] { B return R } ()
+ #define ASSERT_DETAIL_STMTEXPR(B, R) [&] (const char* assert_detail_msvc_pfunc) { B return R } (ASSERT_DETAIL_PFUNC)
  #define ASSERT_DETAIL_WARNING_PRAGMA
- #define ASSERT_DETAIL_PFUNC_INVOKER_V nullptr
+ #define ASSERT_DETAIL_PFUNC_INVOKER_VALUE nullptr
  #define ASSERT_DETAIL_STATIC_CAST_TO_BOOL(x) asserts::detail::static_cast_to_bool(x)
  namespace asserts::detail {
      template<typename T> bool static_cast_to_bool(T&& t) {
@@ -939,7 +939,7 @@ using asserts::ASSERTION;
                                     name ASSERT_DETAIL_COMMA \
                                     type ASSERT_DETAIL_COMMA \
                                     expr_str ASSERT_DETAIL_COMMA \
-                                    ASSERT_DETAIL_PFUNC_INVOKER_V ASSERT_DETAIL_COMMA \
+                                    ASSERT_DETAIL_PFUNC_INVOKER_VALUE ASSERT_DETAIL_COMMA \
                                     assert_detail_arg_strings ASSERT_DETAIL_COMMA \
                                   };
 
@@ -956,7 +956,7 @@ using asserts::ASSERTION;
 // lambdas but that's potentially very expensive compile-time wise. Need to investigate further.
 // Note: asserts::detail::expression_decomposer(asserts::detail::expression_decomposer{} << expr) done for ternary
 #if ASSERT_DETAIL_IS_MSVC
- #define ASSERT_DETAIL_MSVC_PRETTY_FUNCTION_ARG , asserts::detail::msvc_pretty_function_wrapper{ASSERT_DETAIL_PFUNC}
+ #define ASSERT_DETAIL_MSVC_PRETTY_FUNCTION_ARG ,asserts::detail::msvc_pretty_function_wrapper{assert_detail_msvc_pfunc}
 #else
  #define ASSERT_DETAIL_MSVC_PRETTY_FUNCTION_ARG
 #endif

--- a/include/assert.hpp
+++ b/include/assert.hpp
@@ -901,7 +901,9 @@ using asserts::ASSERTION;
 #define ASSERT_DETAIL_COMMA ,
 
 #if ASSERT_DETAIL_IS_CLANG || ASSERT_DETAIL_IS_GCC
- #define ASSERT_DETAIL_STMTEXPR(B, R) __extension__ ({ B R })
+ // Extra set of parentheses here because clang treats __extension__ as a low-precedence unary operator which interferes
+ // with decltype(auto) in an expression like decltype(auto) x = __extension__ ({...}).y;
+ #define ASSERT_DETAIL_STMTEXPR(B, R) (__extension__ ({ B R }))
  #define ASSERT_DETAIL_WARNING_PRAGMA _Pragma("GCC diagnostic ignored \"-Wparentheses\"")
  #define ASSERT_DETAIL_PFUNC_INVOKER_V ASSERT_DETAIL_PFUNC
  #define ASSERT_DETAIL_STATIC_CAST_TO_BOOL(x) static_cast<bool>(x)

--- a/include/assert.hpp
+++ b/include/assert.hpp
@@ -978,7 +978,7 @@ using asserts::ASSERTION;
           asserts::detail::get_expression_return_value \
             <assert_detail_ret_lhs ASSERT_DETAIL_COMMA std::is_lvalue_reference<decltype(assert_detail_value)>::value> \
               (assert_detail_value, *std::launder(&assert_detail_decomposer)); \
-        )
+        ).value
 
 #define ASSERT(expr, ...) ASSERT_INVOKE(expr, true, "ASSERT", assertion, __VA_ARGS__)
 

--- a/src/assert.cpp
+++ b/src/assert.cpp
@@ -1872,7 +1872,12 @@ namespace asserts::detail {
 				end = i;
 			}
 		}
-		return std::pair(start, end);
+		#if !ASSERT_DETAIL_IS_MSVC
+		 int start_offset = 0;
+		#else
+		 int start_offset = 1; // accommodate for lambda being used as statement expression
+		#endif
+		return std::pair(start + start_offset, end);
 	}
 
 	ASSERT_DETAIL_ATTR_COLD

--- a/src/assert.cpp
+++ b/src/assert.cpp
@@ -474,16 +474,17 @@ namespace asserts::detail {
 		};
 	}
 
-	static std::unordered_map<ULONG, std::string> type_cache; // memoize, though it hardly matters
+	//static std::unordered_map<ULONG, std::string> type_cache; // memoize, though it hardly matters
 
 	// top-level type resolution function
 	ASSERT_DETAIL_ATTR_COLD static std::string get_type(ULONG type_index, HANDLE proc, ULONG64 modbase) {
-		if(auto it = type_cache.find(type_index); it != type_cache.end()) {
+		/*if(auto it = type_cache.find(type_index); it != type_cache.end()) {
 			return it->second;
 		} else {
 			auto p = type_cache.insert({ type_index, lookup_type(type_index, proc, modbase) });
 			return p.first->second;
-		}
+		}*/
+		return lookup_type(type_index, proc, modbase);
 	}
 
 	struct function_info {

--- a/src/assert.cpp
+++ b/src/assert.cpp
@@ -2031,6 +2031,8 @@ namespace asserts::detail {
 		}
 	}
 
+	constexpr int min_term_width = 50;
+
 	ASSERT_DETAIL_ATTR_COLD [[nodiscard]]
 	std::string print_binary_diagnostics(size_t term_width, binary_diagnostics_descriptor& diagnostics) {
 		auto& [ lstrings, rstrings, a_sstr, b_sstr, multiple_formats, _ ] = diagnostics;

--- a/tests/integration/expected/clang.txt
+++ b/tests/integration/expected/clang.txt
@@ -412,7 +412,7 @@ Assertion failed at integration/integration.cpp:1802: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1803
+      at integration.cpp:1802
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1004
 # 3 main
@@ -426,7 +426,7 @@ Assertion failed at integration/integration.cpp:1804: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1807
+      at integration.cpp:1804
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1004
 # 3 main
@@ -472,7 +472,7 @@ Assertion failed at integration/integration.cpp:2002: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2006
+      at integration.cpp:2002
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1004
 # 3 main
@@ -629,7 +629,7 @@ Assertion failed at integration/integration.cpp:2201: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2204
+      at integration.cpp:2201
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1004
 # 3 main
@@ -713,8 +713,10 @@ logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=1]
 logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=1]
-logger_type::compl logger_type() [n=1]
+logger_type::logger_type(logger_type&&) [n=1]
 logger_type::compl logger_type() [n=-2]
+logger_type::compl logger_type() [n=-2]
+logger_type::compl logger_type() [n=1]
 --------------------------------------------
 
 logger_type::logger_type() [n=1]
@@ -754,7 +756,11 @@ logger_type::logger_type(logger_type&&) [n=2]
 logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=1]
+logger_type::logger_type(logger_type&&) [n=1]
+logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=2]
+logger_type::compl logger_type() [n=-2]
+logger_type::logger_type(logger_type&&) [n=1]
 logger_type::compl logger_type() [n=-2]
 Verification failed at integration/integration.cpp:2317: void test_class<int>::something_else() [T = int]:
     VERIFY(!(std::is_same<decltype(r), logger_type>::value));
@@ -880,6 +886,10 @@ logger_type::logger_type(logger_type&&) [n=2]
 logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=2]
+logger_type::compl logger_type() [n=-2]
+logger_type::logger_type(logger_type&&) [n=2]
+logger_type::logger_type(logger_type&&) [n=2]
+logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=2]
 logger_type::compl logger_type() [n=-2]

--- a/tests/integration/expected/clang_windows.txt
+++ b/tests/integration/expected/clang_windows.txt
@@ -84,7 +84,7 @@ Assertion failed at integration/integration.cpp:1201: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1202
+      at integration.cpp:1201
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -129,7 +129,7 @@ Assertion failed at integration/integration.cpp:1303: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1304
+      at integration.cpp:1303
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -157,7 +157,7 @@ Assertion failed at integration/integration.cpp:1401: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1402
+      at integration.cpp:1401
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -171,7 +171,7 @@ Assertion failed at integration/integration.cpp:1402: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1403
+      at integration.cpp:1402
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -201,7 +201,7 @@ Verification failed at integration/integration.cpp:1404: void test_class<int>::s
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1405
+      at integration.cpp:1404
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -216,7 +216,7 @@ Assertion failed at integration/integration.cpp:1407: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1408
+      at integration.cpp:1407
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -460,7 +460,7 @@ Assertion failed at integration/integration.cpp:2001: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2002
+      at integration.cpp:2001
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -487,7 +487,7 @@ Assertion failed at integration/integration.cpp:2102: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2103
+      at integration.cpp:2102
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -501,7 +501,7 @@ Assertion failed at integration/integration.cpp:2103: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2104
+      at integration.cpp:2103
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -513,7 +513,7 @@ Assertion failed at integration/integration.cpp:2104: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2105
+      at integration.cpp:2104
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -527,7 +527,7 @@ Assertion failed at integration/integration.cpp:2105: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2106
+      at integration.cpp:2105
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -541,7 +541,7 @@ Assertion failed at integration/integration.cpp:2106: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2107
+      at integration.cpp:2106
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -555,7 +555,7 @@ Assertion failed at integration/integration.cpp:2107: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2108
+      at integration.cpp:2107
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -599,7 +599,7 @@ Assertion failed at integration/integration.cpp:2113: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2114
+      at integration.cpp:2113
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -671,7 +671,7 @@ Assertion failed at integration/integration.cpp:2308: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2310
+      at integration.cpp:2308
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -738,7 +738,7 @@ Assertion failed at integration/integration.cpp:2316: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2317
+      at integration.cpp:2316
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -915,11 +915,20 @@ Assertion failed at integration/integration.cpp:501: void rec(int):
     assert(false);
 
 Stack trace:
-# 1 test_class<int>::something_else()
+# 1 rec(int)
+      at integration.cpp:501
+# 2 rec(int)
+      at integration.cpp:503
+|                                   |
+| 8 layers of recursion were folded |
+|                                   |
+#11 rec(int)
+      at integration.cpp:503
+#12 test_class<int>::something_else()
       at integration.cpp:2602
-# 2 test_class<int>::something<N>(std::pair<N, int>)
+#13 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
-# 3 main()
+#14 main()
       at integration.cpp:403
 
 
@@ -928,11 +937,33 @@ Assertion failed at integration/integration.cpp:508: void recursive_a(int):
     assert(false);
 
 Stack trace:
-# 1 test_class<int>::something_else()
+# 1 recursive_a(int)
+      at integration.cpp:508
+# 2 recursive_b(int)
+      at integration.cpp:515
+# 3 recursive_a(int)
+      at integration.cpp:510
+# 4 recursive_b(int)
+      at integration.cpp:515
+# 5 recursive_a(int)
+      at integration.cpp:510
+# 6 recursive_b(int)
+      at integration.cpp:515
+# 7 recursive_a(int)
+      at integration.cpp:510
+# 8 recursive_b(int)
+      at integration.cpp:515
+# 9 recursive_a(int)
+      at integration.cpp:510
+#10 recursive_b(int)
+      at integration.cpp:515
+#11 recursive_a(int)
+      at integration.cpp:510
+#12 test_class<int>::something_else()
       at integration.cpp:2703
-# 2 test_class<int>::something<N>(std::pair<N, int>)
+#13 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
-# 3 main()
+#14 main()
       at integration.cpp:403
 
 

--- a/tests/integration/expected/clang_windows.txt
+++ b/tests/integration/expected/clang_windows.txt
@@ -293,7 +293,7 @@ Assertion failed at integration/integration.cpp:1701: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1702
+      at integration.cpp:1701
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -341,7 +341,7 @@ Assertion failed at integration/integration.cpp:1705: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1706
+      at integration.cpp:1705
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -397,7 +397,7 @@ Assertion failed at integration/integration.cpp:1709: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1712
+      at integration.cpp:1709
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -412,7 +412,7 @@ Assertion failed at integration/integration.cpp:1802: void test_class<int>::some
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1803
+      at integration.cpp:1802
 # 2 test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main()
@@ -713,6 +713,8 @@ logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=1]
 logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=1]
+logger_type::logger_type(logger_type&&) [n=1]
+logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=1]
 --------------------------------------------
@@ -754,7 +756,11 @@ logger_type::logger_type(logger_type&&) [n=2]
 logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=1]
+logger_type::logger_type(logger_type&&) [n=1]
+logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=2]
+logger_type::compl logger_type() [n=-2]
+logger_type::logger_type(logger_type&&) [n=1]
 logger_type::compl logger_type() [n=-2]
 Verification failed at integration/integration.cpp:2317: void test_class<int>::something_else() [T = int]:
     VERIFY(!(std::is_same<decltype(r), logger_type>::value));
@@ -882,6 +888,10 @@ logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=2]
 logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=2]
+logger_type::logger_type(logger_type&&) [n=2]
+logger_type::compl logger_type() [n=-2]
+logger_type::compl logger_type() [n=-2]
+logger_type::logger_type(logger_type&&) [n=2]
 logger_type::compl logger_type() [n=-2]
 Assertion failed at integration/integration.cpp:2503: void test_class<int>::something_else() [T = int]:
     assert(false, ...);
@@ -932,7 +942,7 @@ Assertion failed at integration/x/a.cpp:5: void test_path_differentiation_2():
 
 Stack trace:
 # 1 test_path_differentiation_2()
-      at x/a.cpp:6
+      at x/a.cpp:5
 # 2 test_path_differentiation()
       at integration/a.cpp:8
 # 3 test_class<int>::something_else()

--- a/tests/integration/expected/gcc.txt
+++ b/tests/integration/expected/gcc.txt
@@ -6,7 +6,7 @@ Assertion failed at integration/integration.cpp:1103: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1104
+      at integration.cpp:1103
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -23,7 +23,7 @@ Assertion failed at integration/integration.cpp:1104: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1105
+      at integration.cpp:1104
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -38,7 +38,7 @@ Assertion failed at integration/integration.cpp:1107: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1108
+      at integration.cpp:1107
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -53,7 +53,7 @@ Assertion failed at integration/integration.cpp:1108: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1109
+      at integration.cpp:1108
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -68,7 +68,7 @@ Assertion failed at integration/integration.cpp:1110: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1101
+      at integration.cpp:1110
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -84,7 +84,7 @@ Assertion failed at integration/integration.cpp:1201: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1202
+      at integration.cpp:1201
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -99,7 +99,7 @@ Assertion failed at integration/integration.cpp:1202: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1203
+      at integration.cpp:1202
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -129,7 +129,7 @@ Assertion failed at integration/integration.cpp:1303: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1304
+      at integration.cpp:1303
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -157,7 +157,7 @@ Assertion failed at integration/integration.cpp:1401: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1402
+      at integration.cpp:1401
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -171,7 +171,7 @@ Assertion failed at integration/integration.cpp:1402: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1403
+      at integration.cpp:1402
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -186,7 +186,7 @@ Assertion failed at integration/integration.cpp:1403: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1404
+      at integration.cpp:1403
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -201,7 +201,7 @@ Verification failed at integration/integration.cpp:1404: void test_class<T>::som
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1405
+      at integration.cpp:1404
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -216,7 +216,7 @@ Assertion failed at integration/integration.cpp:1407: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1408
+      at integration.cpp:1407
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -305,7 +305,7 @@ Assertion failed at integration/integration.cpp:1702: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1703
+      at integration.cpp:1702
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -412,7 +412,7 @@ Assertion failed at integration/integration.cpp:1802: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1803
+      at integration.cpp:1802
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -426,7 +426,7 @@ Assertion failed at integration/integration.cpp:1804: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1807
+      at integration.cpp:1804
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -460,7 +460,7 @@ Assertion failed at integration/integration.cpp:2001: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2002
+      at integration.cpp:2001
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -472,7 +472,7 @@ Assertion failed at integration/integration.cpp:2002: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2006
+      at integration.cpp:2002
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -487,7 +487,7 @@ Assertion failed at integration/integration.cpp:2102: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2103
+      at integration.cpp:2102
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -501,7 +501,7 @@ Assertion failed at integration/integration.cpp:2103: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2104
+      at integration.cpp:2103
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -513,7 +513,7 @@ Assertion failed at integration/integration.cpp:2104: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2105
+      at integration.cpp:2104
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -527,7 +527,7 @@ Assertion failed at integration/integration.cpp:2105: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2106
+      at integration.cpp:2105
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -541,7 +541,7 @@ Assertion failed at integration/integration.cpp:2106: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2107
+      at integration.cpp:2106
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -555,7 +555,7 @@ Assertion failed at integration/integration.cpp:2107: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2108
+      at integration.cpp:2107
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -569,7 +569,7 @@ Assertion failed at integration/integration.cpp:2109: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2110
+      at integration.cpp:2109
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -584,7 +584,7 @@ Assertion failed at integration/integration.cpp:2111: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2112
+      at integration.cpp:2111
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -599,7 +599,7 @@ Assertion failed at integration/integration.cpp:2113: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2114
+      at integration.cpp:2113
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -629,7 +629,7 @@ Assertion failed at integration/integration.cpp:2201: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2204
+      at integration.cpp:2201
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -648,7 +648,7 @@ Assertion failed at integration/integration.cpp:2304: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2303
+      at integration.cpp:2304
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -713,8 +713,10 @@ logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=1]
 logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=1]
-logger_type::compl logger_type() [n=1]
+logger_type::logger_type(logger_type&&) [n=1]
 logger_type::compl logger_type() [n=-2]
+logger_type::compl logger_type() [n=-2]
+logger_type::compl logger_type() [n=1]
 --------------------------------------------
 
 logger_type::logger_type() [n=2]
@@ -754,14 +756,18 @@ logger_type::logger_type(logger_type&&) [n=2]
 logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=1]
+logger_type::logger_type(logger_type&&) [n=1]
+logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=2]
+logger_type::compl logger_type() [n=-2]
+logger_type::logger_type(logger_type&&) [n=1]
 logger_type::compl logger_type() [n=-2]
 Verification failed at integration/integration.cpp:2317: void test_class<T>::something_else() [with T = int]:
     VERIFY(!(std::is_same<decltype(r), logger_type>::value));
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2318
+      at integration.cpp:2317
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -775,7 +781,7 @@ Verification failed at integration/integration.cpp:2318: void test_class<T>::som
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2316
+      at integration.cpp:2318
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -812,7 +818,7 @@ Assertion failed at integration/integration.cpp:2405: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2406
+      at integration.cpp:2405
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -827,7 +833,7 @@ Assertion failed at integration/integration.cpp:2406: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2402
+      at integration.cpp:2406
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -882,6 +888,10 @@ logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=2]
 logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=2]
+logger_type::logger_type(logger_type&&) [n=2]
+logger_type::compl logger_type() [n=-2]
+logger_type::compl logger_type() [n=-2]
+logger_type::logger_type(logger_type&&) [n=2]
 logger_type::compl logger_type() [n=-2]
 Assertion failed at integration/integration.cpp:2503: void test_class<T>::something_else() [with T = int]:
     assert(false, ...);
@@ -890,7 +900,7 @@ Assertion failed at integration/integration.cpp:2503: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2502
+      at integration.cpp:2503
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -906,9 +916,11 @@ Assertion failed at integration/integration.cpp:501: void rec(int):
 
 Stack trace:
 # 1 rec(int)
+      at integration.cpp:501
+# 2 rec(int)
       at integration.cpp:503
 |                                   |
-| 9 layers of recursion were folded |
+| 8 layers of recursion were folded |
 |                                   |
 #11 rec(int)
       at integration.cpp:503
@@ -926,7 +938,7 @@ Assertion failed at integration/integration.cpp:508: void recursive_a(int):
 
 Stack trace:
 # 1 recursive_a(int)
-      at integration.cpp:510
+      at integration.cpp:508
 # 2 recursive_b(int)
       at integration.cpp:515
 # 3 recursive_a(int)
@@ -961,7 +973,7 @@ Assertion failed at integration/x/a.cpp:5: void test_path_differentiation_2():
 
 Stack trace:
 # 1 test_path_differentiation_2()
-      at x/a.cpp:6
+      at x/a.cpp:5
 # 2 test_path_differentiation()
       at integration/a.cpp:8
 # 3 test_class<int>::something_else()

--- a/tests/integration/expected/gcc_windows.txt
+++ b/tests/integration/expected/gcc_windows.txt
@@ -6,7 +6,7 @@ Assertion failed at integration/integration.cpp:1103: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1104
+      at integration.cpp:1103
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -23,7 +23,7 @@ Assertion failed at integration/integration.cpp:1104: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1105
+      at integration.cpp:1104
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -38,7 +38,7 @@ Assertion failed at integration/integration.cpp:1107: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1108
+      at integration.cpp:1107
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -53,7 +53,7 @@ Assertion failed at integration/integration.cpp:1108: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1109
+      at integration.cpp:1108
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -68,7 +68,7 @@ Assertion failed at integration/integration.cpp:1110: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1101
+      at integration.cpp:1110
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -84,7 +84,7 @@ Assertion failed at integration/integration.cpp:1201: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1202
+      at integration.cpp:1201
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -99,7 +99,7 @@ Assertion failed at integration/integration.cpp:1202: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1203
+      at integration.cpp:1202
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -113,7 +113,7 @@ Assertion failed at integration/integration.cpp:1204: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1207
+      at integration.cpp:1204
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -129,7 +129,7 @@ Assertion failed at integration/integration.cpp:1303: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1304
+      at integration.cpp:1303
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -144,7 +144,7 @@ Assertion failed at integration/integration.cpp:1304: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1307
+      at integration.cpp:1304
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -157,7 +157,7 @@ Assertion failed at integration/integration.cpp:1401: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1402
+      at integration.cpp:1401
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -171,7 +171,7 @@ Assertion failed at integration/integration.cpp:1402: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1403
+      at integration.cpp:1402
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -186,7 +186,7 @@ Assertion failed at integration/integration.cpp:1403: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1404
+      at integration.cpp:1403
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -201,7 +201,7 @@ Verification failed at integration/integration.cpp:1404: void test_class<T>::som
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1405
+      at integration.cpp:1404
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -216,7 +216,7 @@ Assertion failed at integration/integration.cpp:1407: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1408
+      at integration.cpp:1407
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -231,7 +231,7 @@ Assertion failed at integration/integration.cpp:1408: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1411
+      at integration.cpp:1408
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -247,7 +247,7 @@ Assertion failed at integration/integration.cpp:1502: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1505
+      at integration.cpp:1502
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -263,7 +263,7 @@ Assertion failed at integration/integration.cpp:1602: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1603
+      at integration.cpp:1602
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -278,7 +278,7 @@ Assertion failed at integration/integration.cpp:1603: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1607
+      at integration.cpp:1603
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -293,7 +293,7 @@ Assertion failed at integration/integration.cpp:1701: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1702
+      at integration.cpp:1701
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -305,7 +305,7 @@ Assertion failed at integration/integration.cpp:1702: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1703
+      at integration.cpp:1702
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -329,7 +329,7 @@ Assertion failed at integration/integration.cpp:1704: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1705
+      at integration.cpp:1704
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -341,7 +341,7 @@ Assertion failed at integration/integration.cpp:1705: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1706
+      at integration.cpp:1705
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -355,7 +355,7 @@ Assertion failed at integration/integration.cpp:1706: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1707
+      at integration.cpp:1706
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -383,7 +383,7 @@ Assertion failed at integration/integration.cpp:1708: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1709
+      at integration.cpp:1708
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -397,7 +397,7 @@ Assertion failed at integration/integration.cpp:1709: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1712
+      at integration.cpp:1709
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -412,7 +412,7 @@ Assertion failed at integration/integration.cpp:1802: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1803
+      at integration.cpp:1802
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -426,7 +426,7 @@ Assertion failed at integration/integration.cpp:1804: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1807
+      at integration.cpp:1804
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -447,7 +447,7 @@ Assertion failed at integration/integration.cpp:1901: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:1904
+      at integration.cpp:1901
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -460,7 +460,7 @@ Assertion failed at integration/integration.cpp:2001: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2002
+      at integration.cpp:2001
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -472,7 +472,7 @@ Assertion failed at integration/integration.cpp:2002: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2006
+      at integration.cpp:2002
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -487,7 +487,7 @@ Assertion failed at integration/integration.cpp:2102: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2103
+      at integration.cpp:2102
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -501,7 +501,7 @@ Assertion failed at integration/integration.cpp:2103: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2104
+      at integration.cpp:2103
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -513,7 +513,7 @@ Assertion failed at integration/integration.cpp:2104: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2105
+      at integration.cpp:2104
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -527,7 +527,7 @@ Assertion failed at integration/integration.cpp:2105: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2106
+      at integration.cpp:2105
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -541,7 +541,7 @@ Assertion failed at integration/integration.cpp:2106: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2107
+      at integration.cpp:2106
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -555,7 +555,7 @@ Assertion failed at integration/integration.cpp:2107: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2108
+      at integration.cpp:2107
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -569,7 +569,7 @@ Assertion failed at integration/integration.cpp:2109: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2110
+      at integration.cpp:2109
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -584,7 +584,7 @@ Assertion failed at integration/integration.cpp:2111: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2112
+      at integration.cpp:2111
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -599,7 +599,7 @@ Assertion failed at integration/integration.cpp:2113: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2114
+      at integration.cpp:2113
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -611,7 +611,7 @@ Assertion failed at integration/integration.cpp:2114: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2117
+      at integration.cpp:2114
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -629,7 +629,7 @@ Assertion failed at integration/integration.cpp:2201: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2204
+      at integration.cpp:2201
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -648,7 +648,7 @@ Assertion failed at integration/integration.cpp:2304: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2303
+      at integration.cpp:2304
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -713,8 +713,10 @@ logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=1]
 logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=1]
-logger_type::compl logger_type() [n=1]
+logger_type::logger_type(logger_type&&) [n=1]
 logger_type::compl logger_type() [n=-2]
+logger_type::compl logger_type() [n=-2]
+logger_type::compl logger_type() [n=1]
 --------------------------------------------
 
 logger_type::logger_type() [n=2]
@@ -754,14 +756,18 @@ logger_type::logger_type(logger_type&&) [n=2]
 logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=1]
+logger_type::logger_type(logger_type&&) [n=1]
+logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=2]
+logger_type::compl logger_type() [n=-2]
+logger_type::logger_type(logger_type&&) [n=1]
 logger_type::compl logger_type() [n=-2]
 Verification failed at integration/integration.cpp:2317: void test_class<T>::something_else() [with T = int]:
     VERIFY(!(std::is_same<decltype(r), logger_type>::value));
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2318
+      at integration.cpp:2317
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -775,7 +781,7 @@ Verification failed at integration/integration.cpp:2318: void test_class<T>::som
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2316
+      at integration.cpp:2318
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -812,7 +818,7 @@ Assertion failed at integration/integration.cpp:2405: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2406
+      at integration.cpp:2405
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -827,7 +833,7 @@ Assertion failed at integration/integration.cpp:2406: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2402
+      at integration.cpp:2406
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -845,7 +851,7 @@ Assertion failed at integration/integration.cpp:2411: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2417
+      at integration.cpp:2411
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -882,6 +888,10 @@ logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=2]
 logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=2]
+logger_type::logger_type(logger_type&&) [n=2]
+logger_type::compl logger_type() [n=-2]
+logger_type::compl logger_type() [n=-2]
+logger_type::logger_type(logger_type&&) [n=2]
 logger_type::compl logger_type() [n=-2]
 Assertion failed at integration/integration.cpp:2503: void test_class<T>::something_else() [with T = int]:
     assert(false, ...);
@@ -890,7 +900,7 @@ Assertion failed at integration/integration.cpp:2503: void test_class<T>::someth
 
 Stack trace:
 # 1 test_class<int>::something_else()
-      at integration.cpp:2502
+      at integration.cpp:2503
 # 2 void test_class<int>::something<N>(std::pair<N, int>)
       at integration.cpp:1005
 # 3 main
@@ -906,9 +916,11 @@ Assertion failed at integration/integration.cpp:501: void rec(int):
 
 Stack trace:
 # 1 rec(int)
+      at integration.cpp:501
+# 2 rec(int)
       at integration.cpp:503
 |                                   |
-| 9 layers of recursion were folded |
+| 8 layers of recursion were folded |
 |                                   |
 #11 rec(int)
       at integration.cpp:503
@@ -926,7 +938,7 @@ Assertion failed at integration/integration.cpp:508: void recursive_a(int):
 
 Stack trace:
 # 1 recursive_a(int)
-      at integration.cpp:510
+      at integration.cpp:508
 # 2 recursive_b(int)
       at integration.cpp:515
 # 3 recursive_a(int)
@@ -961,7 +973,7 @@ Assertion failed at integration/x/a.cpp:5: void test_path_differentiation_2():
 
 Stack trace:
 # 1 test_path_differentiation_2()
-      at x/a.cpp:6
+      at x/a.cpp:5
 # 2 test_path_differentiation()
       at integration/a.cpp:8
 # 3 test_class<int>::something_else()

--- a/tests/integration/expected/msvc.txt
+++ b/tests/integration/expected/msvc.txt
@@ -713,6 +713,8 @@ logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=1]
 logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=1]
+logger_type::logger_type(logger_type&&) [n=1]
+logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=1]
 --------------------------------------------
@@ -754,7 +756,11 @@ logger_type::logger_type(logger_type&&) [n=2]
 logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=1]
+logger_type::logger_type(logger_type&&) [n=1]
+logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=2]
+logger_type::compl logger_type() [n=-2]
+logger_type::logger_type(logger_type&&) [n=1]
 logger_type::compl logger_type() [n=-2]
 Verification failed at integration/integration.cpp:2317: void __cdecl test_class<int>::something_else(void):
     VERIFY(!(std::is_same<decltype(r), logger_type>::value));
@@ -795,7 +801,7 @@ Assertion failed at integration/integration.cpp:2804: decltype(auto) __cdecl tes
 
 Stack trace:
 # 1 test_class<int>::get_lt_a(logger_type&)
-      at integration.cpp:2805
+      at integration.cpp:2804
 # 2 test_class<int>::something_else()
       at integration.cpp:2403
 # 3 test_class<int>::something<N>(std::pair<N, int>)
@@ -880,6 +886,10 @@ logger_type::logger_type(logger_type&&) [n=2]
 logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=2]
+logger_type::compl logger_type() [n=-2]
+logger_type::logger_type(logger_type&&) [n=2]
+logger_type::logger_type(logger_type&&) [n=2]
+logger_type::compl logger_type() [n=-2]
 logger_type::compl logger_type() [n=-2]
 logger_type::logger_type(logger_type&&) [n=2]
 logger_type::compl logger_type() [n=-2]

--- a/tests/unit/type_handling.cpp
+++ b/tests/unit/type_handling.cpp
@@ -50,8 +50,8 @@ struct only_move_constructable {
 };
 
 int main() {
+	// test rvalue
 	{
-		// test rvalue
 		decltype(auto) a = ASSERT(only_move_constructable(2) == 2);
 		static_assert(std::is_same<decltype(a), only_move_constructable>::value);
 		assert(!is_lvalue(ASSERT(only_move_constructable(2) == 2)));
@@ -79,6 +79,14 @@ int main() {
 		ASSERT(v2 == 65536);
 		auto v3 = ASSERT(32 >> 2);
 		ASSERT(v3 == 8);
+	}
+
+	// test CHECK returns nothing
+	{
+		auto f = [] {
+			return CHECK(false);
+		};
+		static_assert(std::is_same<decltype(f()), void>::value);
 	}
 	
 	return 0;

--- a/tests/unit/type_handling.cpp
+++ b/tests/unit/type_handling.cpp
@@ -1,3 +1,5 @@
+#undef ASSERT_LOWERCASE
+#include <cassert>
 #include "assert.hpp"
 
 #include <iostream>
@@ -50,33 +52,33 @@ struct only_move_constructable {
 int main() {
 	{
 		// test rvalue
-		decltype(auto) a = assert(only_move_constructable(2) == 2);
+		decltype(auto) a = ASSERT(only_move_constructable(2) == 2);
 		static_assert(std::is_same<decltype(a), only_move_constructable>::value);
-		assert(!is_lvalue(assert(only_move_constructable(2) == 2)));
-		assert(assert(only_move_constructable(2) == 2).x == 2);
+		assert(!is_lvalue(ASSERT(only_move_constructable(2) == 2)));
+		assert(ASSERT(only_move_constructable(2) == 2).x == 2);
 		//assert(assert(only_move_constructable(2) == 2).x++ == 2); // not allowed
 	}
 
 	// test lvalue
 	{
 		only_move_constructable x(2);
-		decltype(auto) b = assert(x == 2);
+		decltype(auto) b = ASSERT(x == 2);
 		static_assert(std::is_same<decltype(b), only_move_constructable&>::value);
-		assert(is_lvalue(assert(x == 2)));
-		assert(x == 2).x++;
-		assert(x.x == 3);
+		assert(is_lvalue(ASSERT(x == 2)));
+		ASSERT(x == 2).x++;
+		ASSERT(x.x == 3);
 	}
 
 	// above cases test lhs returns, now test the case where the full value is returned
 	{
-		auto v0 = assert(1 | 2);
-		assert(v0 == 3);
-		auto v1 = assert(7 & 4);
-		assert(v1 == 4);
-		auto v2 = assert(1 << 16);
-		assert(v2 == 65536);
-		auto v3 = assert(32 >> 2);
-		assert(v3 == 8);
+		auto v0 = ASSERT(1 | 2);
+		ASSERT(v0 == 3);
+		auto v1 = ASSERT(7 & 4);
+		ASSERT(v1 == 4);
+		auto v2 = ASSERT(1 << 16);
+		ASSERT(v2 == 65536);
+		auto v3 = ASSERT(32 >> 2);
+		ASSERT(v3 == 8);
 	}
 	
 	return 0;


### PR DESCRIPTION
This PR overhauls the assertion invocation to place the branch at macro expansion rather than in a function.

I'd hoped compilers would sink a computation like `vec.capacity()` into a branch if its only needed in a branch but oh well. Getting the computation put into the branch requires a much different invocation system. One behavioral change: Extra diagnostics are now only evaluated in the failure path. I think this is probably a good behavioral change to have anyway.

For the following test:
```c++
void foo(std::vector<int>& vec) {
    ASSERT(vec.size() > 10, "foobar", vec.capacity(), vec[0]);
}
```

Old codegen:
```assembly
foo(std::vector<int, std::allocator<int> >&):               # @foo(std::vector<int, std::allocator<int> >&)
        push    rax
        mov     rax, rdi
        mov     r9, qword ptr [rdi]
        mov     rdi, qword ptr [rdi + 8]
        sub     rdi, r9
        sar     rdi, 2
        mov     rax, qword ptr [rax + 16]
        sub     rax, r9
        sar     rax, 2
        mov     qword ptr [rsp], rax
        cmp     rdi, 10
        jbe     .LBB0_1
        pop     rax
        ret
.LBB0_1:
        mov     r8, rsp
        mov     edx, offset foo(std::vector<int, std::allocator<int> >&)::params
        mov     ecx, offset .L.str.8
        mov     esi, 10
        call    asserts::detail::expression_decomposer<unsigned long, int, asserts::detail::ops::gt> asserts::detail::assert_fail_m<unsigned long, int, asserts::detail::ops::gt, char const (&) [7], unsigned long, int&>(asserts::detail::expression_decomposer<unsigned long, int, asserts::detail::ops::gt>, asserts::detail::assert_static_parameters const*, char const (&) [7], unsigned long&&, int&)
        pop     rax
        ret
```

New codegen:
```assembly
foo(std::vector<int, std::allocator<int> >&):               # @foo(std::vector<int, std::allocator<int> >&)
        push    rax
        mov     rax, rdi
        mov     r9, qword ptr [rdi]
        mov     rdi, qword ptr [rdi + 8]
        sub     rdi, r9
        sar     rdi, 2
        cmp     rdi, 10
        jbe     .LBB0_1
        pop     rax
        ret
.LBB0_1:
        mov     rax, qword ptr [rax + 16]
        sub     rax, r9
        sar     rax, 2
        mov     qword ptr [rsp], rax
        mov     r8, rsp
        mov     edx, offset foo(std::vector<int, std::allocator<int> >&)::assert_detail_params
        mov     ecx, offset .L.str.8
        mov     esi, 10
        call    asserts::detail::expression_decomposer<unsigned long, int, asserts::detail::ops::gt> asserts::detail::assert_fail_m<unsigned long, int, asserts::detail::ops::gt, char const (&) [7], unsigned long, int&>(asserts::detail::expression_decomposer<unsigned long, int, asserts::detail::ops::gt>, asserts::detail::assert_static_parameters const*, char const (&) [7], unsigned long&&, int&)
        pop     rax
        ret
```
<https://godbolt.org/z/3MKhc86z5>